### PR TITLE
python3

### DIFF
--- a/python_src/src/leagueinstaller.py
+++ b/python_src/src/leagueinstaller.py
@@ -105,7 +105,7 @@ def league_install_code(game_main_dir, game_region_link):
         file.write("[Desktop Entry]\n")
         file.write("Name=League of Legends (Python Launcher)\n")
         file.write("Comment=Play League of Legends on Linux\n")
-        file.write(f'Exec=python "{game_launch_file_path}"\n')
+        file.write(f'Exec=python3 "{game_launch_file_path}"\n')
         file.write("Terminal=false\n")
         file.write("Icon=leagueoflol\n")
         file.write("Type=Application\n")


### PR DESCRIPTION
In some distros python command doesn't exist (by default) so python3 command should ensure that doesn't happen. 