### PR TITLE
Add Taiwan server support

### DIFF
--- a/src/installer.ui
+++ b/src/installer.ui
@@ -1762,6 +1762,11 @@
                </item>
                <item>
                 <property name="text">
+                 <string extracomment="tw2">TW (TW2) - Taiwan</string>
+                </property>
+               </item>
+               <item>
+                <property name="text">
                  <string extracomment="tr">TR (TR1) - Turkey</string>
                 </property>
                </item>

--- a/src/lol-for-linux-installer.py
+++ b/src/lol-for-linux-installer.py
@@ -500,6 +500,7 @@ class Installer(QMainWindow):
                 "RU (RU1) - Russia": "ru",
                 "EUW (EUW1) - Europe West": "euw",
                 "EUNE (EUN1) - Europe Nordic & East": "eune",
+                "TW (TW2) - Taiwan": "tw2",
                 "TR (TR1) - Turkey": "tr",
                 "JP (JP1) - Japan": "jp",
                 "KR (KR) - Republic of Korea": "kr",


### PR DESCRIPTION
I found this repo a while ago, as a Taiwanese, I found that the installation options are missing the Taiwan server, so I modified the code a little, and now I can choose to install the Taiwan server.