### PR TITLE
Move invalid app ID to app name

### DIFF
--- a/src/lolforlinuxinstaller.desktop
+++ b/src/lolforlinuxinstaller.desktop
@@ -2,7 +2,7 @@
 Version=1.0
 Name=League of Legends (lol-for-linux-installer)
 Comment=Launch lol-for-linux-installer
-Exec=com.kassindornelles.lolforlinuxinstaller
+Exec=lolforlinuxinstaller
 Icon=/usr/share/lol-for-linux-installer/lolforlinuxinstaller.svg
 Terminal=false
 Type=Application

--- a/src/lolforlinuxinstaller.py
+++ b/src/lolforlinuxinstaller.py
@@ -591,7 +591,7 @@ class QTextEditLogger(logging.Handler, QObject):
 
 if __name__ == '__main__':
     app = QApplication(sys.argv)
-    app.setDesktopFileName("com.kassindornelles.lolforlinuxinstaller")
+    app.setDesktopFileName("lolforlinuxinstaller")
     if os.getuid() == 0:
         msg_box = QMessageBox()
         msg_box.setText("Don't run this as sudo user")


### PR DESCRIPTION
The app ID is invalid, as it should be using the website's domain and invert it. However, "kassindornelles.com" doesn't exist, so the app ID is entirely invalid. In the future, we should use `io.github.kassindornelles.lol_for_linux_installer` as the website is hosted on GitHub (replacing hyphens with underscores to keep the name legal everywhere).