### PR TITLE
Initial Discord Rich Presence support

### DIFF
--- a/src/installer.ui
+++ b/src/installer.ui
@@ -281,7 +281,7 @@
              <item>
               <widget class="QTabWidget" name="tabWidget">
                <property name="currentIndex">
-                <number>1</number>
+                <number>0</number>
                </property>
                <property name="tabsClosable">
                 <bool>false</bool>
@@ -301,39 +301,7 @@
                  <string>Home</string>
                 </attribute>
                 <layout class="QGridLayout" name="gridLayout_5">
-                 <item row="13" column="1" rowspan="2">
-                  <spacer name="verticalSpacer">
-                   <property name="orientation">
-                    <enum>Qt::Vertical</enum>
-                   </property>
-                   <property name="sizeType">
-                    <enum>QSizePolicy::Preferred</enum>
-                   </property>
-                   <property name="sizeHint" stdset="0">
-                    <size>
-                     <width>10</width>
-                     <height>20</height>
-                    </size>
-                   </property>
-                  </spacer>
-                 </item>
-                 <item row="15" column="2">
-                  <spacer name="horizontalSpacer_9">
-                   <property name="orientation">
-                    <enum>Qt::Horizontal</enum>
-                   </property>
-                   <property name="sizeType">
-                    <enum>QSizePolicy::Fixed</enum>
-                   </property>
-                   <property name="sizeHint" stdset="0">
-                    <size>
-                     <width>1</width>
-                     <height>1</height>
-                    </size>
-                   </property>
-                  </spacer>
-                 </item>
-                 <item row="15" column="1">
+                 <item row="16" column="1">
                   <layout class="QHBoxLayout" name="horizontalLayout_8">
                    <item>
                     <widget class="QPushButton" name="donatebutton">
@@ -406,6 +374,70 @@
                    </item>
                   </layout>
                  </item>
+                 <item row="1" column="1" rowspan="2">
+                  <spacer name="verticalSpacer_3">
+                   <property name="orientation">
+                    <enum>Qt::Vertical</enum>
+                   </property>
+                   <property name="sizeType">
+                    <enum>QSizePolicy::Expanding</enum>
+                   </property>
+                   <property name="sizeHint" stdset="0">
+                    <size>
+                     <width>20</width>
+                     <height>40</height>
+                    </size>
+                   </property>
+                  </spacer>
+                 </item>
+                 <item row="16" column="0">
+                  <spacer name="horizontalSpacer_10">
+                   <property name="orientation">
+                    <enum>Qt::Horizontal</enum>
+                   </property>
+                   <property name="sizeType">
+                    <enum>QSizePolicy::Fixed</enum>
+                   </property>
+                   <property name="sizeHint" stdset="0">
+                    <size>
+                     <width>1</width>
+                     <height>1</height>
+                    </size>
+                   </property>
+                  </spacer>
+                 </item>
+                 <item row="16" column="2">
+                  <spacer name="horizontalSpacer_9">
+                   <property name="orientation">
+                    <enum>Qt::Horizontal</enum>
+                   </property>
+                   <property name="sizeType">
+                    <enum>QSizePolicy::Fixed</enum>
+                   </property>
+                   <property name="sizeHint" stdset="0">
+                    <size>
+                     <width>1</width>
+                     <height>1</height>
+                    </size>
+                   </property>
+                  </spacer>
+                 </item>
+                 <item row="14" column="1" rowspan="2">
+                  <spacer name="verticalSpacer">
+                   <property name="orientation">
+                    <enum>Qt::Vertical</enum>
+                   </property>
+                   <property name="sizeType">
+                    <enum>QSizePolicy::Preferred</enum>
+                   </property>
+                   <property name="sizeHint" stdset="0">
+                    <size>
+                     <width>10</width>
+                     <height>20</height>
+                    </size>
+                   </property>
+                  </spacer>
+                 </item>
                  <item row="11" column="1">
                   <layout class="QVBoxLayout" name="verticalLayout_8">
                    <property name="spacing">
@@ -466,6 +498,42 @@
                     </spacer>
                    </item>
                    <item>
+                    <widget class="QCheckBox" name="Richpresence">
+                     <property name="sizePolicy">
+                      <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
+                       <horstretch>0</horstretch>
+                       <verstretch>0</verstretch>
+                      </sizepolicy>
+                     </property>
+                     <property name="toolTip">
+                      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Enable Discord Rich Presence, provided by league-rpc-linux&lt;/p&gt;&lt;p&gt;&lt;a href=&quot;https://github.com/FeralInteractive/gamemode&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#007af4;&quot;&gt;https://github.com/daglaroglou/league-rpc-linux&lt;/span&gt;&lt;/a&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                     </property>
+                     <property name="text">
+                      <string>Enable Discord Rich Presence</string>
+                     </property>
+                     <property name="icon">
+                      <iconset theme="discord">
+                       <normaloff>.</normaloff>.</iconset>
+                     </property>
+                    </widget>
+                   </item>
+                   <item>
+                    <spacer name="verticalSpacer_16">
+                     <property name="orientation">
+                      <enum>Qt::Vertical</enum>
+                     </property>
+                     <property name="sizeType">
+                      <enum>QSizePolicy::Fixed</enum>
+                     </property>
+                     <property name="sizeHint" stdset="0">
+                      <size>
+                       <width>5</width>
+                       <height>10</height>
+                      </size>
+                     </property>
+                    </spacer>
+                   </item>
+                   <item>
                     <widget class="QCheckBox" name="skiplaunchercheck">
                      <property name="enabled">
                       <bool>true</bool>
@@ -498,38 +566,6 @@
                     </widget>
                    </item>
                   </layout>
-                 </item>
-                 <item row="15" column="0">
-                  <spacer name="horizontalSpacer_10">
-                   <property name="orientation">
-                    <enum>Qt::Horizontal</enum>
-                   </property>
-                   <property name="sizeType">
-                    <enum>QSizePolicy::Fixed</enum>
-                   </property>
-                   <property name="sizeHint" stdset="0">
-                    <size>
-                     <width>1</width>
-                     <height>1</height>
-                    </size>
-                   </property>
-                  </spacer>
-                 </item>
-                 <item row="1" column="1" rowspan="2">
-                  <spacer name="verticalSpacer_3">
-                   <property name="orientation">
-                    <enum>Qt::Vertical</enum>
-                   </property>
-                   <property name="sizeType">
-                    <enum>QSizePolicy::Expanding</enum>
-                   </property>
-                   <property name="sizeHint" stdset="0">
-                    <size>
-                     <width>20</width>
-                     <height>40</height>
-                    </size>
-                   </property>
-                  </spacer>
                  </item>
                 </layout>
                </widget>

--- a/src/launch-script.py
+++ b/src/launch-script.py
@@ -37,9 +37,6 @@ wine_process = [
     "--launch-patchline=live"
 ]
 
-print(wine_process)
-
-subprocess.Popen(['python3', '/home/rafal/league-rpc-linux/main.py'])
 subprocess.run(wine_process, env=start_game_vars, check=True)
 
 

--- a/src/launch-script.py
+++ b/src/launch-script.py
@@ -37,7 +37,9 @@ wine_process = [
     "--launch-patchline=live"
 ]
 
-subprocess.run(wine_process, env=start_game_vars, check=True)
+print(wine_process)
 
+subprocess.Popen(['python3', '/home/rafal/league-rpc-linux/main.py'])
+subprocess.run(wine_process, env=start_game_vars, check=True)
 
 

--- a/src/leagueinstaller_code.py
+++ b/src/leagueinstaller_code.py
@@ -30,13 +30,15 @@ def install_dxvk_code(game_main_dir):
 def install_richpresence_code(game_main_dir):
     rpcUrl = 'https://github.com/daglaroglou/league-rpc-linux/archive/refs/heads/main.zip'
     rpcFilename = os.path.basename(rpcUrl)
+    rpcDir = os.path.join(game_main_dir, 'league-rpc-linux-main')
     urllib.request.urlretrieve(rpcUrl, rpcFilename)
 
     with zipfile.ZipFile(rpcFilename) as rpcZip:
         rpcZip.extractall()
 
     os.remove(rpcFilename)
-    subprocess.Popen(['python3', os.path.join(game_main_dir, "league-rpc-linux-main", "setup.py")])
+    subprocess.run(['python3', '-m', 'venv', os.path.join(rpcDir, 'venv')])
+    subprocess.run([os.path.join(rpcDir, 'venv', 'bin', 'pip'), 'install', '-r', os.path.join(rpcDir, 'requirements.txt')])
 
 def league_install_code(game_main_dir, game_region_link):
     logging.info("Setting all variables")

--- a/src/leagueinstaller_code.py
+++ b/src/leagueinstaller_code.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-import os, shutil, requests, tarfile, zipfile, subprocess, json, logging, urllib.request
+import os, shutil, requests, tarfile, subprocess, json, logging, urllib.request
 
 def install_dxvk_code(game_main_dir):
     dst_path = os.path.join(game_main_dir, 'wine', 'prefix', 'drive_c', 'windows')
@@ -26,19 +26,6 @@ def install_dxvk_code(game_main_dir):
 
     os.remove(filename)
     shutil.rmtree(tmp_path)
-
-def install_richpresence_code(game_main_dir):
-    rpcUrl = 'https://github.com/daglaroglou/league-rpc-linux/archive/refs/heads/main.zip'
-    rpcFilename = os.path.basename(rpcUrl)
-    rpcDir = os.path.join(game_main_dir, 'league-rpc-linux-main')
-    urllib.request.urlretrieve(rpcUrl, rpcFilename)
-
-    with zipfile.ZipFile(rpcFilename) as rpcZip:
-        rpcZip.extractall()
-
-    os.remove(rpcFilename)
-    subprocess.run(['python3', '-m', 'venv', os.path.join(rpcDir, 'venv')])
-    subprocess.run([os.path.join(rpcDir, 'venv', 'bin', 'pip'), 'install', '-r', os.path.join(rpcDir, 'requirements.txt')])
 
 def league_install_code(game_main_dir, game_region_link):
     logging.info("Setting all variables")
@@ -118,9 +105,6 @@ def league_install_code(game_main_dir, game_region_link):
     except FileNotFoundError:
         logging.warning(f"Directory {game_downloads_dir} does not exist")
     logging.info("Delete temp folders")
-
     logging.info("Installing DXVK 1.10.3...")
     install_dxvk_code(game_main_dir)
-    logging.info("Installing Discord Rich Presence...")
-    install_richpresence_code(game_main_dir)
     logging.info("Finishing...")

--- a/src/leagueinstaller_code.py
+++ b/src/leagueinstaller_code.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-import os, shutil, requests, tarfile, subprocess, json, logging, urllib.request
+import os, shutil, requests, tarfile, zipfile, subprocess, json, logging, urllib.request
 
 def install_dxvk_code(game_main_dir):
     dst_path = os.path.join(game_main_dir, 'wine', 'prefix', 'drive_c', 'windows')
@@ -26,6 +26,17 @@ def install_dxvk_code(game_main_dir):
 
     os.remove(filename)
     shutil.rmtree(tmp_path)
+
+def install_richpresence_code(game_main_dir):
+    rpcUrl = 'https://github.com/daglaroglou/league-rpc-linux/archive/refs/heads/main.zip'
+    rpcFilename = os.path.basename(rpcUrl)
+    urllib.request.urlretrieve(rpcUrl, rpcFilename)
+
+    with zipfile.ZipFile(rpcFilename) as rpcZip:
+        rpcZip.extractall()
+
+    os.remove(rpcFilename)
+    subprocess.Popen(['python3', os.path.join(game_main_dir, "league-rpc-linux-main", "setup.py")])
 
 def league_install_code(game_main_dir, game_region_link):
     logging.info("Setting all variables")
@@ -108,4 +119,6 @@ def league_install_code(game_main_dir, game_region_link):
 
     logging.info("Installing DXVK 1.10.3...")
     install_dxvk_code(game_main_dir)
+    logging.info("Installing Discord Rich Presence...")
+    install_richpresence_code(game_main_dir)
     logging.info("Finishing...")

--- a/src/lolforlinuxinstaller.py
+++ b/src/lolforlinuxinstaller.py
@@ -44,6 +44,7 @@ class Installer(QMainWindow):
             loadUi("/usr/share/lol-for-linux-installer/installer.ui", self)
         self.slider_value_changed = False
         self.game_installed_folder = None
+        self.game_rpc_folder = None
         self.gamemode_value = None
         self.richpresence_value = None
         self.skiplauncher_value = None
@@ -90,6 +91,7 @@ class Installer(QMainWindow):
 
                 self.load_env_vars(env_vars, self)
                 self.download_winebuild_json()
+                self.game_rpc_folder = os.path.join(self.game_installed_folder, 'league-rpc-linux-main')
 
         except FileNotFoundError:
             self.stackedWidget.setCurrentWidget(self.welcome)
@@ -164,7 +166,7 @@ class Installer(QMainWindow):
         else:
             self.Usegamemode.setChecked(False)
 
-        if game_settings.get("RichPresence") == "1":
+        if game_settings.get("Richpresence") == "1":
             self.Richpresence.setChecked(True)
         else:
             self.Richpresence.setChecked(False)
@@ -280,8 +282,8 @@ class Installer(QMainWindow):
         env_vars['game_settings']['Gamemode'] = '1' if self.Usegamemode.isChecked() else '0'
         self.gamemode_value = int(env_vars['game_settings']['Gamemode'])
 
-        env_vars['game_settings']['RichPresence'] = '1' if self.Richpresence.isChecked() else '0'
-        self.richpresence_value = int(env_vars['game_settings']['RichPresence'])
+        env_vars['game_settings']['Richpresence'] = '1' if self.Richpresence.isChecked() else '0'
+        self.richpresence_value = int(env_vars['game_settings']['Richpresence'])
 
         env_vars['game_settings']['Skiplauncher'] = '1' if self.skiplaunchercheck.isChecked() else '0'
         self.skiplauncher_value = int(env_vars['game_settings']['Skiplauncher'])
@@ -382,10 +384,10 @@ class Installer(QMainWindow):
             env_vars = json.load(env_vars_file)
             game_settings = env_vars.get('game_settings', {})
             gamemode_value = int(game_settings.get('Gamemode', '0'))
-            richpresence_value = int(game_settings.get('RichPresence', '0'))
+            richpresence_value = int(game_settings.get('Richpresence', '0'))
             
         if richpresence_value == 1:
-            richPresenceLaunch = subprocess.Popen(['python3', os.path.join(self.game_installed_folder, "league-rpc-linux-main", "main.py")])
+            richPresenceLaunch = subprocess.Popen([os.path.join(self.game_rpc_folder, 'venv', 'bin', 'python3'), os.path.join(self.game_rpc_folder, "main.py")])
             print("Using Rich Presence.")
         else:
             print("Not using Rich Presence.")

--- a/src/lolforlinuxinstaller.py
+++ b/src/lolforlinuxinstaller.py
@@ -45,6 +45,7 @@ class Installer(QMainWindow):
         self.slider_value_changed = False
         self.game_installed_folder = None
         self.gamemode_value = None
+        self.richpresence_value = None
         self.skiplauncher_value = None
         self.vkbasaltslider = self.findChild(QSlider, "vkbasaltslider")
         self.setWindowTitle('LolForLinuxInstaller')
@@ -61,6 +62,7 @@ class Installer(QMainWindow):
         self.Usedriprime.stateChanged.connect(self.toggleapplybutton)
         self.Usenvidiahybrid.stateChanged.connect(self.toggleapplybutton)
         self.obsvkcapturecheck.stateChanged.connect(self.toggleapplybutton)
+        self.Richpresence.clicked.connect(self.toggleapplybutton)
         self.Usegamemode.clicked.connect(self.toggleapplybutton)
         self.nextWelcome.clicked.connect(self.regionWidget)
         self.nextRegion.clicked.connect(self.optionsWidget)
@@ -161,6 +163,12 @@ class Installer(QMainWindow):
             self.Usegamemode.setChecked(True)
         else:
             self.Usegamemode.setChecked(False)
+
+        if game_settings.get("RichPresence") == "1":
+            self.Richpresence.setChecked(True)
+        else:
+            self.Richpresence.setChecked(False)
+
 
         if game_settings.get("Skiplauncher") == "0":
             self.skiplaunchercheck.setChecked(False)
@@ -272,6 +280,9 @@ class Installer(QMainWindow):
         env_vars['game_settings']['Gamemode'] = '1' if self.Usegamemode.isChecked() else '0'
         self.gamemode_value = int(env_vars['game_settings']['Gamemode'])
 
+        env_vars['game_settings']['RichPresence'] = '1' if self.Richpresence.isChecked() else '0'
+        self.richpresence_value = int(env_vars['game_settings']['RichPresence'])
+
         env_vars['game_settings']['Skiplauncher'] = '1' if self.skiplaunchercheck.isChecked() else '0'
         self.skiplauncher_value = int(env_vars['game_settings']['Skiplauncher'])
 
@@ -371,6 +382,13 @@ class Installer(QMainWindow):
             env_vars = json.load(env_vars_file)
             game_settings = env_vars.get('game_settings', {})
             gamemode_value = int(game_settings.get('Gamemode', '0'))
+            richpresence_value = int(game_settings.get('RichPresence', '0'))
+            
+        if richpresence_value == 1:
+            richPresenceLaunch = subprocess.Popen(['python3', os.path.join(self.game_installed_folder, "league-rpc-linux-main", "main.py")])
+            print("Using Rich Presence.")
+        else:
+            print("Not using Rich Presence.")
 
         if gamemode_value == 1:
             process = subprocess.Popen(['gamemoderun', 'python3', '/usr/share/lol-for-linux-installer/launch-script.py'])


### PR DESCRIPTION
Finally, the days of "playing **wine64-preloader**" are over!

This uses @daglaroglou's [league-rpc-linux](https://github.com/daglaroglou/league-rpc-linux/) in order to provide the installation, and use of Discord Rich Presence on the launcher, which can be toggled on and off. I've tried to get [wine-discord-ipc-bridge](https://github.com/0e4ef622/wine-discord-ipc-bridge) working, but to no avail. There are some known issues with this, as it's just a quick and dirty implementation I did for myself and decided to share, but it should be functional enough. I'll list them here along with some screenshots.

**Known Issues:**

- ~~I did not contact the author of the script, neither did I got his permission to use it here, so I'm not sure I can just plop this in.~~ **I contacted the author, there's no issue using it here.**
- ~~Also, distros like Arch have a externally managed python environment from which they install packages, instead of using pip. This could be fixed/overridden by using the --break-system-packages flag to install the script dependencies, but it could be potentially unsafe.~~ **Fixed by using a venv installation of dependencies.**
- ~~Some distros may not use the "_python3_" command to execute python scripts, just "_python_".~~ **Looking back on it, I'm almost sure _python3_ is universal. Either way, the latest commit executes the venv executable directly so it's now a non-issue.**
- There may be more that I'm missing, so if there's a better way to do anything here, feel free to change stuff as needed.

![image](https://github.com/kassindornelles/lol-for-linux-installer/assets/89185603/f8f7d74e-f256-4591-9cf1-c74f670be6f1)

![image](https://github.com/kassindornelles/lol-for-linux-installer/assets/89185603/2cda8e1f-c29f-4d96-8c3e-2fa331090cd8)
